### PR TITLE
Add opencv to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+opencv-python


### PR DESCRIPTION
## Summary
- add `opencv-python` to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*