### PR TITLE
Fix parameter control and compare GUI

### DIFF
--- a/cam_tuner_gui/ui/compare.py
+++ b/cam_tuner_gui/ui/compare.py
@@ -7,6 +7,9 @@ from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import QDockWidget, QLabel, QHBoxLayout, QWidget
 
 
+__all__ = ["CompareDock"]
+
+
 class CompareDock(QDockWidget):
     """두 스트림을 나란히 비교하는 도킹 위젯."""
 
@@ -56,3 +59,17 @@ class CompareDock(QDockWidget):
                 )
             pixmap = QPixmap.fromImage(qimage)
         label.setPixmap(pixmap)
+
+
+if __name__ == "__main__":
+    import sys
+    from PySide6.QtWidgets import QApplication, QMainWindow
+
+    app = QApplication(sys.argv)
+    window = QMainWindow()
+    dock = CompareDock(window)
+    window.addDockWidget(Qt.RightDockWidgetArea, dock)
+    window.resize(800, 400)
+    window.show()
+    sys.exit(app.exec())
+

--- a/cam_tuner_gui/ui/main.py
+++ b/cam_tuner_gui/ui/main.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
-from PySide6.QtCore import QTimer
-from PySide6.QtWidgets import QMainWindow, QLabel, QVBoxLayout, QWidget
+from PySide6.QtCore import QTimer, Qt
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
 
 from cam_tuner_gui.metric.metrics import calc_snr
+from cam_tuner_gui.capture.device import CameraDevice
+from cam_tuner_gui.control.params import set_param
 
 
 class MainWindow(QMainWindow):
@@ -15,33 +28,127 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("Camera Tuner")
 
+        # Top control bar
+        self._device_combo = QComboBox()
+        self._device_combo.addItem("0")
+        self._start_btn = QPushButton("Start")
+        self._stop_btn = QPushButton("Stop")
+        top_bar = QHBoxLayout()
+        top_bar.addWidget(self._device_combo)
+        top_bar.addWidget(self._start_btn)
+        top_bar.addWidget(self._stop_btn)
+
+        # Preview and snapshot area
+        self._preview_label = QLabel()
+        self._preview_label.setAlignment(Qt.AlignCenter)
+        self._snapshot_label = QLabel()
+        self._snapshot_label.setAlignment(Qt.AlignCenter)
+        preview_row = QHBoxLayout()
+        preview_row.addWidget(self._preview_label)
+        preview_row.addWidget(self._snapshot_label)
+
+        # Metrics
         self._snr_label = QLabel("SNR: -- dB")
+
+        # Sliders for basic controls
+        self._exp_slider = QSlider(Qt.Horizontal)
+        self._exp_slider.setRange(1, 1000)
+        self._exp_slider.setValue(100)
+        self._gain_slider = QSlider(Qt.Horizontal)
+        self._gain_slider.setRange(0, 255)
+        controls_col = QVBoxLayout()
+        controls_col.addWidget(QLabel("Exposure"))
+        controls_col.addWidget(self._exp_slider)
+        controls_col.addWidget(QLabel("Gain"))
+        controls_col.addWidget(self._gain_slider)
+
+        self._snapshot_btn = QPushButton("Snapshot")
+        self._export_btn = QPushButton("Export Report")
+        bottom_bar = QHBoxLayout()
+        bottom_bar.addWidget(self._snapshot_btn)
+        bottom_bar.addWidget(self._export_btn)
+
         container = QWidget()
         layout = QVBoxLayout(container)
+        layout.addLayout(top_bar)
+        layout.addLayout(preview_row)
         layout.addWidget(self._snr_label)
+        layout.addLayout(controls_col)
+        layout.addLayout(bottom_bar)
         self.setCentralWidget(container)
 
         self.device = None
         self._timer = QTimer(self)
-        self._timer.timeout.connect(self._update_metrics)
+        self._timer.timeout.connect(self._update_frame)
 
-    def _update_metrics(self) -> None:
+        self._start_btn.clicked.connect(self._start_stream)
+        self._stop_btn.clicked.connect(self._stop_stream)
+        self._snapshot_btn.clicked.connect(self._take_snapshot)
+        self._exp_slider.valueChanged.connect(self._apply_exposure)
+        self._gain_slider.valueChanged.connect(self._apply_gain)
+
+    def _ndarray_to_pixmap(self, frame) -> QPixmap:
+        height, width = frame.shape[:2]
+        if len(frame.shape) == 2:
+            qimage = QImage(frame.data, width, height, frame.strides[0], QImage.Format_Grayscale8)
+        else:
+            qimage = QImage(frame.data, width, height, frame.strides[0], QImage.Format_BGR888)
+        return QPixmap.fromImage(qimage)
+
+    def _update_frame(self) -> None:
         if self.device is None:
             return
         frame = self.device.read_frame()
-        if frame is None:
-            return
+        pixmap = self._ndarray_to_pixmap(frame)
+        self._preview_label.setPixmap(pixmap)
         snr = calc_snr(frame)
         self._snr_label.setText(f"SNR: {snr:.2f} dB")
 
+    def _start_stream(self) -> None:
+        if self.device is None:
+            device_id = self._device_combo.currentText()
+            self.device = CameraDevice(device_id)
+        self.device.start_stream()
+        self._apply_exposure(self._exp_slider.value())
+        self._apply_gain(self._gain_slider.value())
+        self._timer.start(30)
+
+    def _stop_stream(self) -> None:
+        if self.device:
+            self.device.stop_stream()
+        self._timer.stop()
+
+    def _take_snapshot(self) -> None:
+        if self.device is None:
+            return
+        frame = self.device.read_frame()
+        self._snapshot_label.setPixmap(self._ndarray_to_pixmap(frame))
+
+    def _apply_exposure(self, value: int) -> None:
+        if self.device and self.device.cap and self.device.cap.isOpened():
+            try:
+                set_param(self.device.cap, "auto_exposure", 1)
+                set_param(self.device.cap, "exposure_abs", value)
+            except Exception:
+                pass
+
+    def _apply_gain(self, value: int) -> None:
+        if self.device and self.device.cap and self.device.cap.isOpened():
+            try:
+                set_param(self.device.cap, "gain", value)
+            except Exception:
+                pass
+
     def show(self) -> None:
         super().show()
-        self._timer.start(1000)
+        # Stream is started via button
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        self._stop_stream()
+        super().closeEvent(event)
 
 if __name__ == "__main__":
     import sys
-    from PySide6.QtWidgets import QApplication
-
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()


### PR DESCRIPTION
## Summary
- hook exposure and gain sliders up to camera parameters
- apply slider values when starting the stream
- add simple main entry point for `CompareDock`

## Testing
- `pytest -q`